### PR TITLE
feat: cors config for api gatway

### DIFF
--- a/environments/Testing/config.tfvars
+++ b/environments/Testing/config.tfvars
@@ -1,6 +1,7 @@
 environment = "testing"
 service-config-search = {
-  aws_opensearch_instance_type        = "t3.small.elasticsearch"
-  aws_opensearch_instance_count       = 1
-  aws_opensearch_instance_volume_size = 10
+  aws_opensearch_instance_type         = "t3.small.elasticsearch"
+  aws_opensearch_instance_count        = 1
+  aws_opensearch_instance_volume_size  = 10
+  aws_api_gateway_cors_allowed_origins = ["dev.hackney.gov.uk"]
 }

--- a/src/framework/service/api.tf
+++ b/src/framework/service/api.tf
@@ -1,6 +1,9 @@
 resource "aws_apigatewayv2_api" "api" {
   name          = "${var.system}-${var.environment}-${var.name}"
   protocol_type = "HTTP"
+  cors_configuration {
+    allow_origins = var.config.api.cors.origins
+  }
 }
 
 resource "aws_apigatewayv2_stage" "api" {

--- a/src/framework/service/variables.tf
+++ b/src/framework/service/variables.tf
@@ -6,6 +6,11 @@ variable "name" {
 variable "config" {
   description = "The service configuration"
   type = object({
+    api = object({
+      cors = object({
+        origins = set(string)
+      })
+    })
     actions = list(object({
       name                  = string
       handler               = string

--- a/src/services/search/infrastructure.tf
+++ b/src/services/search/infrastructure.tf
@@ -34,9 +34,10 @@ variable "environment" {
 variable "service-config-search" {
   description = "The configuration object for this service."
   type = object({
-    aws_opensearch_instance_type        = string
-    aws_opensearch_instance_count       = number
-    aws_opensearch_instance_volume_size = number
+    aws_opensearch_instance_type         = string
+    aws_opensearch_instance_count        = number
+    aws_opensearch_instance_volume_size  = number
+    aws_api_gateway_cors_allowed_origins = set(string)
   })
 }
 
@@ -123,6 +124,11 @@ module "service" {
   system      = var.system
   environment = var.environment
   config = {
+    api = {
+      cors = {
+        origins = var.service-config-search.aws_api_gateway_cors_allowed_origins
+      }
+    }
     actions = [
       {
         name            = "search"


### PR DESCRIPTION
### What?

Add the ability to configure cors setting for api gateway.

### Why?

Because the search engine should be callable from the frontend.

### How?

Add a cors configuration variable for the service configuration.
